### PR TITLE
Fix 17 bugs in customization and installer stability

### DIFF
--- a/src/InstallWorker.cpp
+++ b/src/InstallWorker.cpp
@@ -371,6 +371,5 @@ void InstallWorker::sendConfigs()
 
     for (const QString &cmd : commands) {
         sendInput(cmd);
-        QThread::msleep(200);
     }
 }

--- a/src/ObsidianOSInstaller.cpp
+++ b/src/ObsidianOSInstaller.cpp
@@ -116,7 +116,11 @@ void ObsidianOSInstaller::goBack()
 
 void ObsidianOSInstaller::goNext()
 {
-    validateCurrentPage();
+    if (m_currentPage >= 11) {
+        close();
+        return;
+    }
+
     if (m_currentPage == 1) {
         DiskSelectionPage *diskPage = qobject_cast<DiskSelectionPage*>(m_pages[1]);
         QString selectedDisk = diskPage->getSelectedDisk();
@@ -144,26 +148,6 @@ void ObsidianOSInstaller::goNext()
     }
 }
 
-void ObsidianOSInstaller::validateCurrentPage()
-{
-    if (m_currentPage == 1) {
-        DiskSelectionPage *diskPage = qobject_cast<DiskSelectionPage*>(m_pages[1]);
-        QString selectedDisk = diskPage->getSelectedDisk();
-        if (selectedDisk.isEmpty() || selectedDisk == "ERROR") {
-            QMessageBox::warning(this, "Validation Error", "Please select a valid disk for installation.");
-            return;
-        }
-    }
-    if (m_currentPage == 8) {
-        UserPage *userPage = qobject_cast<UserPage*>(m_pages[8]);
-        QPair<bool, QString> result = userPage->validate();
-        if (!result.first) {
-            QMessageBox::warning(this, "Validation Error", result.second);
-            return;
-        }
-    }
-}
-
 void ObsidianOSInstaller::updateButtons()
 {
     m_backButton->setEnabled(m_currentPage > 0 && m_currentPage < 10);
@@ -181,8 +165,6 @@ void ObsidianOSInstaller::updateButtons()
         m_nextButton->setIcon(QIcon::fromTheme("application-exit"));
         m_installButton->hide();
         m_backButton->setEnabled(false);
-        disconnect(m_nextButton, &QPushButton::clicked, this, &ObsidianOSInstaller::goNext);
-        connect(m_nextButton, &QPushButton::clicked, this, &ObsidianOSInstaller::close);
     } else {
         m_nextButton->show();
         m_nextButton->setText("Continue");
@@ -235,6 +217,7 @@ void ObsidianOSInstaller::startInstallation()
     UserPage *userPage = qobject_cast<UserPage*>(m_pages[8]);
     InstallationPage *installationPage = qobject_cast<InstallationPage*>(m_pages[10]);
 
+    disconnect(installationPage, &InstallationPage::installationComplete, this, &ObsidianOSInstaller::installationFinished);
     connect(installationPage, &InstallationPage::installationComplete, this, &ObsidianOSInstaller::installationFinished);
 
     installationPage->startInstallation(
@@ -263,6 +246,8 @@ void ObsidianOSInstaller::installationFinished(bool success, const QString &mess
         updateButtons();
 
         FinishedPage *finishedPage = qobject_cast<FinishedPage*>(m_pages[11]);
+        disconnect(finishedPage, &FinishedPage::restartSystem, this, &ObsidianOSInstaller::restartSystem);
+        disconnect(finishedPage, &FinishedPage::showLog, this, &ObsidianOSInstaller::showLog);
         connect(finishedPage, &FinishedPage::restartSystem, this, &ObsidianOSInstaller::restartSystem);
         connect(finishedPage, &FinishedPage::showLog, this, &ObsidianOSInstaller::showLog);
     } else {
@@ -285,7 +270,8 @@ void ObsidianOSInstaller::restartSystem()
 void ObsidianOSInstaller::showLog()
 {
     InstallationPage *installationPage = qobject_cast<InstallationPage*>(m_pages[10]);
-    QString logText = installationPage->findChild<QTextEdit*>("log-output")->toPlainText();
+    QTextEdit *logOutput = installationPage ? installationPage->findChild<QTextEdit*>("log-output") : nullptr;
+    QString logText = logOutput ? logOutput->toPlainText() : "No log data available.";
 
     QDialog *dialog = new QDialog(this);
     dialog->setWindowTitle("Installation Log");

--- a/src/ObsidianOSInstaller.h
+++ b/src/ObsidianOSInstaller.h
@@ -27,7 +27,6 @@ public:
 private slots:
     void goBack();
     void goNext();
-    void validateCurrentPage();
     void updateButtons();
     void updateSummary();
     void startInstallation();

--- a/src/Pages.cpp
+++ b/src/Pages.cpp
@@ -112,7 +112,7 @@ void DiskSelectionPage::scanDisks()
 
     QProcess process;
     process.start("lsblk", {"-d", "-n", "-o", "NAME,SIZE,MODEL"});
-    process.waitForFinished();
+    process.waitForFinished(5000);
     QString output = process.readAllStandardOutput();
     QStringList lines = output.split('\n');
     for (const QString &line : lines) {
@@ -429,7 +429,7 @@ LocalePage::LocalePage(QWidget *parent)
     m_localeList->setMinimumHeight(300);
     QProcess process;
     process.start("ls", {"/usr/share/locale"});
-    process.waitForFinished();
+    process.waitForFinished(5000);
     QString output = process.readAllStandardOutput();
     QStringList locales = output.split('\n');
     for (const QString &loc : locales) {
@@ -470,6 +470,9 @@ void LocalePage::filterLocales()
 void LocalePage::onLocaleSelected(QListWidgetItem *item)
 {
     m_selectedLocale = item->text().trimmed();
+    if (!m_selectedLocale.contains('.')) {
+        m_selectedLocale.append(".UTF-8");
+    }
 }
 
 TimezonePage::TimezonePage(QWidget *parent)
@@ -501,7 +504,7 @@ TimezonePage::TimezonePage(QWidget *parent)
     m_tzList->setMinimumHeight(300);
     QProcess process;
     process.start("timedatectl", {"list-timezones"});
-    process.waitForFinished();
+    process.waitForFinished(5000);
     QString output = process.readAllStandardOutput();
     QStringList timezones = output.split('\n');
     for (const QString &tz : timezones) {
@@ -697,7 +700,7 @@ KeyboardPage::KeyboardPage(QWidget *parent)
     m_kbList->setMinimumHeight(300);
     QProcess process;
     process.start("localectl", {"list-keymaps"});
-    process.waitForFinished();
+    process.waitForFinished(5000);
     QString output = process.readAllStandardOutput();
     QStringList keyboards = output.split('\n');
     for (const QString &kb : keyboards) {
@@ -970,8 +973,13 @@ void InstallationPage::startInstallation(const QString &disk, const QString &ima
         m_isYNPromptActive = true;
     });
 
-    connect(m_worker, &InstallWorker::finished, [this]() {
-        m_worker = nullptr;
+    connect(m_worker, &InstallWorker::finished, this, [this, worker = QPointer<InstallWorker>(m_worker)]() {
+        if (m_worker == worker) {
+            m_worker = nullptr;
+        }
+        if (worker) {
+            worker->deleteLater();
+        }
     });
 
     m_worker->start();
@@ -994,33 +1002,9 @@ void InstallationPage::sendInput()
     }
 }
 
-void InstallationPage::sendYN(const QString &choice)
-{
-    m_logText->append(QString(">>> %1").arg(choice));
-    if (m_worker) {
-        m_worker->sendInput(choice);
-    }
-    m_questionLabel->hide();
-    m_yesButton->hide();
-    m_noButton->hide();
-    m_inputField->show();
-    m_sendButton->show();
-    m_isYNPromptActive = false;
-    m_inputField->clear();
-}
-
 void InstallationPage::updateProgress(const QString &message)
 {
     m_statusLabel->setText("Installation in progress...");
-    if (message.contains("Do you want to chroot into slot 'a' to make changes before copying it to slot B? (y/N):")) {
-        m_questionLabel->show();
-        m_yesButton->show();
-        m_noButton->show();
-        m_inputField->hide();
-        m_sendButton->hide();
-        m_isYNPromptActive = true;
-    }
-
     m_logText->append(message);
     QTextCursor cursor = m_logText->textCursor();
     cursor.movePosition(QTextCursor::End);
@@ -1046,10 +1030,17 @@ void InstallationPage::installationFinished(bool success, const QString &message
 void InstallationPage::onChrootEntered()
 {
     QMessageBox::StandardButton reply = QMessageBox::question(
-        this, "Chroot", "You are now in chroot. Do you still want to be in chroot?",
+        this, "Chroot", "You are now in chroot. Apply system customizations (locale, timezone, keyboard, user account)?",
         QMessageBox::Yes | QMessageBox::No, QMessageBox::Yes
     );
-    if (reply == QMessageBox::No) {
+    if (reply == QMessageBox::Yes) {
+        if (m_worker) {
+            m_worker->sendConfigs();
+        }
+    } else {
+        if (m_worker) {
+            m_worker->sendInput("exit");
+        }
     }
 }
 

--- a/src/Pages.h
+++ b/src/Pages.h
@@ -26,6 +26,7 @@
 #include <QFileInfo>
 #include <QStandardPaths>
 #include <QRegularExpression>
+#include <QPointer>
 #include "InstallWorker.h"
 class WelcomePage : public QWidget
 {
@@ -203,7 +204,6 @@ signals:
 
 private slots:
     void sendInput();
-    void sendYN(const QString &choice);
     void updateProgress(const QString &message);
     void installationFinished(bool success, const QString &message);
     void onChrootEntered();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,5 @@
 #include <QApplication>
 #include <QDir>
-#include <QStyleFactory>
 #include "ObsidianOSInstaller.h"
 #include "Common.h"
 


### PR DESCRIPTION
- sendConfigs() never called; now invoked from onChrootEntered()
- Locale missing .UTF-8 encoding suffix
- validateCurrentPage() caused double validation warnings
- Signal stacking on installationComplete and FinishedPage signals
- Fragile disconnect/connect signal swapping in updateButtons
- Null-pointer crash in showLog()
- Blocking msleep in sendConfigs() removed
- InstallWorker memory leak (no parent, no delete on finish)
- Duplicate chroot detection with wrong string pattern
- Dead sendYN() method and unused QStyleFactory include
- 4x process.waitForFinished() without timeout (lsblk, ls, timedatectl, localectl)